### PR TITLE
Validate the JWT audience claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ It is mainly intended for testing, but can be also used in environment where the
 
 Setting this variable doesn't change the issuer used during JWT validation.
 
+### pg_oidc_validator.audience
+
+This variable controls the expected value of the `aud` claim of the provided JWT token.
+
+The `aud` claim names the service a token was minted for.
+An issuer typically serves several services, so without this check any token from the configured issuer is accepted,
+including one a user obtained for an unrelated service.
+Setting this variable to the identifier the provider uses for PostgreSQL (with most providers, the client id)
+restricts logins to tokens actually intended for this server.
+
+The claim may be a single string or a list of strings; the configured value has to be present in either case.
+
+By default this variable is empty, which keeps the `aud` claim unvalidated.
+The validator writes a message to the server log on every authentication while that is the case.
+
 ## Usage
 
 Use a connection string with OAuth to connect to the server.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Setting this variable doesn't change the issuer used during JWT validation.
 
 ### pg_oidc_validator.audience
 
-This variable controls the expected value of the `aud` claim of the provided JWT token.
+This variable controls which values are accepted in the `aud` claim of the provided JWT token.
 
 The `aud` claim names the service a token was minted for.
 An issuer typically serves several services, so without this check any token from the configured issuer is accepted,
@@ -66,7 +66,16 @@ including one a user obtained for an unrelated service.
 Setting this variable to the identifier the provider uses for PostgreSQL (with most providers, the client id)
 restricts logins to tokens actually intended for this server.
 
-The claim may be a single string or a list of strings; the configured value has to be present in either case.
+The value is a comma separated list, and a token is accepted if its `aud` claim names any of the listed audiences.
+More than one entry is useful while migrating between client ids or providers;
+each entry is another service whose tokens this server accepts.
+Elements containing whitespace or a comma have to be double quoted.
+
+```
+pg_oidc_validator.audience = 'postgres-client,api://postgres'
+```
+
+The claim itself may be either a string or an array of strings, and both are matched against the list.
 
 By default this variable is empty, which keeps the `aud` claim unvalidated.
 The validator writes a message to the server log on every authentication while that is the case.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ The claim itself may be either a string or an array of strings, and both are mat
 By default this variable is empty, which keeps the `aud` claim unvalidated.
 The validator writes a message to the server log on every authentication while that is the case.
 
+A value that is not a well formed list is reported as a `WARNING` when it is loaded, and refuses every OAuth login
+until it is corrected, naming the reason in the server log each time.
+It deliberately does not fall back to leaving the `aud` claim unvalidated,
+which would turn a typo into a silently disabled check.
+
 ## Usage
 
 Use a connection string with OAuth to connect to the server.

--- a/src/jwk.cpp
+++ b/src/jwk.cpp
@@ -193,9 +193,11 @@ jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const audie
 
     const auto& key_object = key_value.get<picojson::object>();
 
-    const std::string use = get_required_parameter(key_object, "use");
+    // RFC 7517 4.2 makes `use` optional, and a key that omits it is not restricted to one purpose, so skip a
+    // key only when it says it is meant for something other than signatures.
+    const auto use_it = key_object.find("use");
 
-    if (use != "sig") {
+    if (use_it != key_object.end() && use_it->second.to_str() != "sig") {
       continue;
     }
 

--- a/src/jwk.cpp
+++ b/src/jwk.cpp
@@ -121,8 +121,8 @@ std::string get_required_parameter(picojson::object const& key_object, std::stri
   return key_object.at(name).to_str();
 }
 
-jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const picojson::value& jwksInfo,
-                                          const std::string& required_kid) {
+jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const std::string& audience,
+                                          const picojson::value& jwksInfo, const std::string& required_kid) {
   std::string expected_issuer = issuer;
 
   if (issuer_is_azure(issuer)) {
@@ -135,6 +135,14 @@ jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const picoj
   }
 
   auto verifier = jwt::verify().with_issuer(expected_issuer);
+
+  if (!audience.empty()) {
+    verifier = verifier.with_audience(audience);
+  } else {
+    elog(LOG,
+         "pg_oidc_validator.audience is not set; the JWT `aud` claim is not validated, so an access token the issuer "
+         "minted for another service is accepted");
+  }
 
   if (!jwksInfo.is<picojson::object>()) {
     throw std::runtime_error("JWKS info is not a JSON object");

--- a/src/jwk.cpp
+++ b/src/jwk.cpp
@@ -33,6 +33,41 @@ std::string convert_azure_issuer_to_jwt_format(const std::string& config_issuer)
   return config_issuer;
 }
 
+// jwt-cpp's with_audience() requires the token to carry *every* configured audience, and rejects a string `aud`
+// outright as soon as more than one is configured. A list of accepted audiences needs the opposite: the token has
+// to name any one of them.
+struct audience_is_accepted {
+  audiences_t accepted;
+
+  void operator()(const jwt::verify_ops::verify_context<jwt::traits::kazuho_picojson>& ctx, std::error_code& ec) const {
+    const auto claim = ctx.get_claim(false, ec);
+
+    if (ec) {
+      return;
+    }
+
+    if (claim.get_type() == jwt::json::type::string) {
+      if (!accepted.contains(claim.as_string())) {
+        ec = jwt::error::token_verification_error::audience_missmatch;
+      }
+      return;
+    }
+
+    if (claim.get_type() != jwt::json::type::array) {
+      ec = jwt::error::token_verification_error::claim_type_missmatch;
+      return;
+    }
+
+    for (const auto& value : claim.as_array()) {
+      if (value.is<std::string>() && accepted.contains(value.get<std::string>())) {
+        return;
+      }
+    }
+
+    ec = jwt::error::token_verification_error::audience_missmatch;
+  }
+};
+
 }  // namespace
 
 void configure_rsa_key(const picojson::object& keyObject, const std::string& kid, const std::string& alg,
@@ -121,7 +156,7 @@ std::string get_required_parameter(picojson::object const& key_object, std::stri
   return key_object.at(name).to_str();
 }
 
-jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const std::string& audience,
+jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const audiences_t& accepted_audiences,
                                           const picojson::value& jwksInfo, const std::string& required_kid) {
   std::string expected_issuer = issuer;
 
@@ -136,8 +171,8 @@ jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const std::
 
   auto verifier = jwt::verify().with_issuer(expected_issuer);
 
-  if (!audience.empty()) {
-    verifier = verifier.with_audience(audience);
+  if (!accepted_audiences.empty()) {
+    verifier = verifier.with_claim("aud", audience_is_accepted{accepted_audiences});
   } else {
     elog(LOG,
          "pg_oidc_validator.audience is not set; the JWT `aud` claim is not validated, so an access token the issuer "

--- a/src/jwk.hpp
+++ b/src/jwk.hpp
@@ -7,14 +7,16 @@
 #if __has_include(<flat_set>)
 #include <flat_set>
 using scopes_t = std::flat_set<std::string>;
+using audiences_t = std::flat_set<std::string>;
 #else
 #include <set>
 using scopes_t = std::set<std::string>;
+using audiences_t = std::set<std::string>;
 #endif
 
 using jwt_verifier = jwt::verifier<jwt::default_clock, jwt::traits::kazuho_picojson>;
 
-jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const std::string& audience,
+jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const audiences_t& accepted_audiences,
                                           const picojson::value& jwksInfo, const std::string& required_kid);
 
 std::string issuer_info_url(std::string const& issuer_url);

--- a/src/jwk.hpp
+++ b/src/jwk.hpp
@@ -14,8 +14,8 @@ using scopes_t = std::set<std::string>;
 
 using jwt_verifier = jwt::verifier<jwt::default_clock, jwt::traits::kazuho_picojson>;
 
-jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const picojson::value& jwksInfo,
-                                          const std::string& required_kid);
+jwt_verifier configure_verifier_with_jwks(const std::string& issuer, const std::string& audience,
+                                          const picojson::value& jwksInfo, const std::string& required_kid);
 
 std::string issuer_info_url(std::string const& issuer_url);
 

--- a/src/pg_oidc_validator.cpp
+++ b/src/pg_oidc_validator.cpp
@@ -107,7 +107,10 @@ extern "C" void _PG_init() {
       gettext_noop("A token is accepted if its `aud` claim names any of the listed audiences. If left empty, the "
                    "`aud` claim is not validated, and an access token the issuer minted for another service is "
                    "accepted as a login."),
-      &audience, "", PGC_SIGHUP, GUC_LIST_INPUT | GUC_LIST_QUOTE, check_audience, nullptr, nullptr);
+      // No GUC_LIST_QUOTE: init_custom_variable() rejects that flag with elog(FATAL) because pg_dump cannot
+      // re-quote a list belonging to an extension that is not loaded. SplitGUCList() honours double quoted
+      // elements regardless of the flag, so only re-quoting on output is lost.
+      &audience, "", PGC_SIGHUP, GUC_LIST_INPUT, check_audience, nullptr, nullptr);
 }
 
 bool validate_token(const ValidatorModuleState* state, const char* token, const char* role,

--- a/src/pg_oidc_validator.cpp
+++ b/src/pg_oidc_validator.cpp
@@ -40,6 +40,9 @@ static char* authn_field = nullptr;
 // When non-empty, the validator uses this URL (instead of pg_hba's `issuer=`)
 static char* discovery_url_override = nullptr;
 
+// When non-empty, the JWT `aud` claim has to contain this value
+static char* audience = nullptr;
+
 extern "C" void _PG_init() {
   DefineCustomStringVariable("pg_oidc_validator.authn_field",
                              gettext_noop("OAuth field used for matching PostgreSQL users"), nullptr, &authn_field,
@@ -49,6 +52,11 @@ extern "C" void _PG_init() {
       gettext_noop("If set, fetch OIDC discovery and JWKS from this URL instead of the pg_hba issuer."),
       gettext_noop("The JWT `iss` claim is still validated against the pg_hba issuer."), &discovery_url_override, "",
       PGC_SIGHUP, 0, nullptr, nullptr, nullptr);
+  DefineCustomStringVariable(
+      "pg_oidc_validator.audience", gettext_noop("If set, the JWT `aud` claim has to contain this value."),
+      gettext_noop("If left empty, the `aud` claim is not validated, and an access token the issuer minted for "
+                   "another service is accepted as a login."),
+      &audience, "", PGC_SIGHUP, 0, nullptr, nullptr, nullptr);
 }
 
 bool validate_token(const ValidatorModuleState* state, const char* token, const char* role,
@@ -69,6 +77,7 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
   const std::string issuer = MyProcPort->hba->oauth_issuer;
   const std::string discovery_url =
       (discovery_url_override != nullptr && *discovery_url_override != '\0') ? discovery_url_override : issuer;
+  const std::string expected_audience = (audience != nullptr) ? audience : "";
 
   http_client http;
   const auto issuer_info = http.get_json(issuer_info_url(discovery_url));
@@ -95,7 +104,7 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
   const auto jwks_info = http.get_json(jwks_uri);
   const auto decoded_token = jwt::decode(token);
   const std::string jwt_kid = decoded_token.get_header_claim("kid").as_string();
-  const auto verifier = configure_verifier_with_jwks(issuer, jwks_info, jwt_kid);
+  const auto verifier = configure_verifier_with_jwks(issuer, expected_audience, jwks_info, jwt_kid);
   verifier.verify(decoded_token);
   auto received_scopes = parse_jwt_scopes(decoded_token.get_payload_json()["scp"]);
   const auto json_scope = parse_jwt_scopes(decoded_token.get_payload_json()["scope"]);

--- a/src/pg_oidc_validator.cpp
+++ b/src/pg_oidc_validator.cpp
@@ -19,7 +19,9 @@ extern "C" {
 #include "libpq/libpq-be.h"
 #include "libpq/oauth.h"
 #include "miscadmin.h"
+#include "nodes/pg_list.h"
 #include "utils/guc.h"
+#include "utils/varlena.h"
 
 PG_MODULE_MAGIC_EXT(.name = ModuleName, .version = ModuleVersion);
 }
@@ -40,8 +42,56 @@ static char* authn_field = nullptr;
 // When non-empty, the validator uses this URL (instead of pg_hba's `issuer=`)
 static char* discovery_url_override = nullptr;
 
-// When non-empty, the JWT `aud` claim has to contain this value
+// When non-empty, a comma separated list of audiences; the JWT `aud` claim has to name one of them
 static char* audience = nullptr;
+
+// Splits the audience GUC into its elements. Returns nullptr on success, otherwise a message describing why the
+// value is not a valid list.
+static const char* split_audience_list(const char* value, audiences_t& audiences) {
+  if (value == nullptr || *value == '\0') {
+    return nullptr;
+  }
+
+  // SplitGUCList() carves the list up in place and returns pointers into rawstring, so it has to stay alive until
+  // the elements have been copied out.
+  char* rawstring = pstrdup(value);
+  List* elements = NIL;
+  const char* error = nullptr;
+
+  if (SplitGUCList(rawstring, ',', &elements)) {
+    const int count = list_length(elements);
+
+    for (int i = 0; i < count; i++) {
+      const auto* element = static_cast<const char*>(list_nth(elements, i));
+
+      if (*element == '\0') {
+        error = "audience must not be empty";
+        break;
+      }
+
+      audiences.insert(element);
+    }
+  } else {
+    error = "list syntax is invalid";
+  }
+
+  list_free(elements);
+  pfree(rawstring);
+
+  return error;
+}
+
+static bool check_audience(char** newval, void**, GucSource) {
+  audiences_t audiences;
+  const char* error = split_audience_list(*newval, audiences);
+
+  if (error != nullptr) {
+    GUC_check_errdetail("%s", error);
+    return false;
+  }
+
+  return true;
+}
 
 extern "C" void _PG_init() {
   DefineCustomStringVariable("pg_oidc_validator.authn_field",
@@ -53,10 +103,11 @@ extern "C" void _PG_init() {
       gettext_noop("The JWT `iss` claim is still validated against the pg_hba issuer."), &discovery_url_override, "",
       PGC_SIGHUP, 0, nullptr, nullptr, nullptr);
   DefineCustomStringVariable(
-      "pg_oidc_validator.audience", gettext_noop("If set, the JWT `aud` claim has to contain this value."),
-      gettext_noop("If left empty, the `aud` claim is not validated, and an access token the issuer minted for "
-                   "another service is accepted as a login."),
-      &audience, "", PGC_SIGHUP, 0, nullptr, nullptr, nullptr);
+      "pg_oidc_validator.audience", gettext_noop("Comma separated list of audiences accepted in the JWT `aud` claim."),
+      gettext_noop("A token is accepted if its `aud` claim names any of the listed audiences. If left empty, the "
+                   "`aud` claim is not validated, and an access token the issuer minted for another service is "
+                   "accepted as a login."),
+      &audience, "", PGC_SIGHUP, GUC_LIST_INPUT | GUC_LIST_QUOTE, check_audience, nullptr, nullptr);
 }
 
 bool validate_token(const ValidatorModuleState* state, const char* token, const char* role,
@@ -77,7 +128,15 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
   const std::string issuer = MyProcPort->hba->oauth_issuer;
   const std::string discovery_url =
       (discovery_url_override != nullptr && *discovery_url_override != '\0') ? discovery_url_override : issuer;
-  const std::string expected_audience = (audience != nullptr) ? audience : "";
+  audiences_t accepted_audiences;
+  const char* audience_error = pg::pg_try([&]() { return split_audience_list(audience, accepted_audiences); });
+
+  if (audience_error != nullptr) {
+    // check_audience() rejects such a value when it is set, so this only catches one that slipped through. Refuse
+    // the login rather than silently dropping the audience check.
+    elog(WARNING, "OAuth failed: pg_oidc_validator.audience is invalid: %s", audience_error);
+    return false;
+  }
 
   http_client http;
   const auto issuer_info = http.get_json(issuer_info_url(discovery_url));
@@ -104,7 +163,7 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
   const auto jwks_info = http.get_json(jwks_uri);
   const auto decoded_token = jwt::decode(token);
   const std::string jwt_kid = decoded_token.get_header_claim("kid").as_string();
-  const auto verifier = configure_verifier_with_jwks(issuer, expected_audience, jwks_info, jwt_kid);
+  const auto verifier = configure_verifier_with_jwks(issuer, accepted_audiences, jwks_info, jwt_kid);
   verifier.verify(decoded_token);
   auto received_scopes = parse_jwt_scopes(decoded_token.get_payload_json()["scp"]);
   const auto json_scope = parse_jwt_scopes(decoded_token.get_payload_json()["scope"]);

--- a/src/pg_oidc_validator.cpp
+++ b/src/pg_oidc_validator.cpp
@@ -45,9 +45,9 @@ static char* discovery_url_override = nullptr;
 // When non-empty, a comma separated list of audiences; the JWT `aud` claim has to name one of them
 static char* audience = nullptr;
 
-// Splits the audience GUC into its elements. Returns nullptr on success, otherwise a message describing why the
-// value is not a valid list.
-static const char* split_audience_list(const char* value, audiences_t& audiences) {
+// Splits the audience GUC into its elements, or, when `audiences` is null, only checks that the value is a well
+// formed list. Returns nullptr on success, otherwise a message describing why it is not.
+static const char* split_audience_list(const char* value, audiences_t* audiences) {
   if (value == nullptr || *value == '\0') {
     return nullptr;
   }
@@ -69,7 +69,9 @@ static const char* split_audience_list(const char* value, audiences_t& audiences
         break;
       }
 
-      audiences.insert(element);
+      if (audiences != nullptr) {
+        audiences->insert(element);
+      }
     }
   } else {
     error = "list syntax is invalid";
@@ -81,13 +83,16 @@ static const char* split_audience_list(const char* value, audiences_t& audiences
   return error;
 }
 
+// Reports a malformed list as soon as it is configured, but deliberately accepts it. Returning false would leave
+// the GUC at its previous value --- its empty default, at postmaster startup, where core downgrades a rejected
+// value to a WARNING and carries on --- and an empty audience means "do not validate `aud`", so a typo would
+// silently switch the check off. The value has to reach validate_token(), which refuses the login instead.
 static bool check_audience(char** newval, void**, GucSource) {
-  audiences_t audiences;
-  const char* error = split_audience_list(*newval, audiences);
+  const char* error = split_audience_list(*newval, nullptr);
 
   if (error != nullptr) {
-    GUC_check_errdetail("%s", error);
-    return false;
+    ereport(WARNING, (errmsg("invalid value for parameter \"pg_oidc_validator.audience\": \"%s\"", *newval),
+                      errdetail("%s", error), errhint("OAuth logins are refused until this is corrected.")));
   }
 
   return true;
@@ -132,11 +137,11 @@ bool validate_token(const ValidatorModuleState* state, const char* token, const 
   const std::string discovery_url =
       (discovery_url_override != nullptr && *discovery_url_override != '\0') ? discovery_url_override : issuer;
   audiences_t accepted_audiences;
-  const char* audience_error = pg::pg_try([&]() { return split_audience_list(audience, accepted_audiences); });
+  const char* audience_error = pg::pg_try([&]() { return split_audience_list(audience, &accepted_audiences); });
 
   if (audience_error != nullptr) {
-    // check_audience() rejects such a value when it is set, so this only catches one that slipped through. Refuse
-    // the login rather than silently dropping the audience check.
+    // check_audience() only warns about a malformed value, so it reaches us intact. Refuse the login rather than
+    // fall back to no audience check at all.
     elog(WARNING, "OAuth failed: pg_oidc_validator.audience is invalid: %s", audience_error);
     return false;
   }


### PR DESCRIPTION
Resolves #49.

The verifier was built with an issuer check only, so any signature-valid, unexpired token from the
configured issuer authenticated, whichever service it was minted for. PostgreSQL delegates all token
validation to the validator module, and the [upstream design
notes](https://www.postgresql.org/docs/18/oauth-validator-design.html) list audience among the claims
a validator is expected to check. #49 has the full argument.

## What this does

Adds `pg_oidc_validator.audience`: a comma separated list, `PGC_SIGHUP`, `GUC_LIST_INPUT`, default
empty, passed into `configure_verifier_with_jwks()`.

- **Set** — the token's `aud` claim has to name any one of the listed audiences, or the login fails.
  Both claim shapes RFC 7519 allows are matched: a string `aud`, and an array containing one of them.
  An absent `aud` is a failure. More than one entry is useful while migrating between client ids or
  providers. Elements containing whitespace or a comma are double quoted.
- **Left empty** — behaviour is exactly as before, and the validator writes one line per
  authentication to the server log saying `aud` is not validated.
- **Malformed** — reported as a `WARNING` when it is loaded, and every login is refused until it is
  corrected. See "Failing closed" below; this is the one behaviour that is not simply additive.

`pg_hba.conf` has no `audience` option and a validator module cannot add one, so a GUC is the only
place the setting can live.

`jwt-cpp`'s `with_audience()` cannot express this. It requires the token to carry *every* configured
audience, and rejects a string `aud` outright once more than one is configured. The check is
therefore a small verify op of its own.

Also fixes two things found while reviewing, both pre-existing on `main` and both reported by
@kfox1111 on this PR:

- **`GUC_LIST_QUOTE` made the module impossible to load** (9717ede). `init_custom_variable()` refuses
  that flag with `elog(FATAL, "extensions cannot define GUC_LIST_QUOTE variables")` — `pg_dump` has
  no way to re-quote a list belonging to an extension that is not loaded. A validator module is
  loaded during authentication, so it killed the backend before any token was examined and every
  OAuth login failed. Introduced by ea6afb8 in this PR; `GUC_LIST_INPUT` alone is correct.
  `SplitGUCList()` honours double quoted elements regardless of the flag, so nothing about the input
  changes.
- **The JWKS `use` parameter was treated as required** (3db6549). RFC 7517 §4.2 makes it OPTIONAL,
  and a key that omits it is not restricted to one purpose, but `get_required_parameter()` threw on
  the first such key and took down verification for the whole JWKS. It now skips a key only when it
  says it is meant for something other than signatures. Independent of audience — happy to lift it
  into its own PR if you would rather review it separately.

## Failing closed

`check_audience()` originally rejected a malformed value. That looked careful and was the opposite:
core deliberately downgrades a rejected value to a `WARNING` and carries on, since the module is
halfway through being loaded, so the GUC kept its previous value — its **empty default**, at
postmaster startup. Empty means "do not validate `aud`", so a typo in `postgresql.conf` silently
switched the check off, and a backend cannot tell that state from "never configured".

The hook now reports the problem and accepts the value, so it reaches `validate_token()`, which
refuses the login and names the reason. The value staying visible in `SHOW` is what makes it
diagnosable. The trade-off: a previously good value no longer survives a bad reload. That is the
point — what the file says is what the server enforces, and it refuses rather than guesses.

## Testing

I could not add this to the existing suite honestly: `test/` is a single end-to-end device-flow spec
that needs PostgreSQL 18, Keycloak, and Chrome plus chromedriver, and covering audience there means
reworking the shared Keycloak realm fixtures so tokens carry a known `aud` — a much larger and more
invasive diff than the fix.

What I did instead was drive a **real PG 18.6 backend** doing OAUTHBEARER validation: a fake HTTPS
OIDC provider serving discovery and JWKS from a generated RSA key, `pg_hba.conf` as in `test/`
(`scope="email pgscope",issuer=...,map=emap`), and `src/oauth_conn_test.cpp` supplying each minted
token, so every row below is an actual login attempt with an actual server-side verdict.

### Audience

| `aud` in token | `pg_oidc_validator.audience` | result | server log |
|---|---|---|---|
| `"postgres-client"` | `postgres-client` | **ACCEPTED** | |
| `"some-other-service"` | `postgres-client` | **REFUSED** | `token doesn't contain the required audience` |
| *absent* | `postgres-client` | **REFUSED** | `decoded JWT is missing required claim(s)` |
| `["some-other","postgres-client","third"]` | `postgres-client` | **ACCEPTED** | |
| `["some-other","third"]` | `postgres-client` | **REFUSED** | `token doesn't contain the required audience` |
| `null` | `postgres-client` | **REFUSED** | `invalid type` |
| `"some-other-service"` | *unset* | **ACCEPTED** | + the "not validated" line |
| *absent* | *unset* | **ACCEPTED** | + the "not validated" line |
| `"api://postgres"` | `postgres-client,api://postgres` | **ACCEPTED** | second list entry |
| `"aud with space"` | `postgres-client,"aud with space"` | **ACCEPTED** | quoted entry |
| `"nope"` | `postgres-client,api://postgres` | **REFUSED** | `token doesn't contain the required audience` |

On unmodified `main` the second row **accepts**, which is the gap in #49.

### Malformed value, at reload and at startup

| `pg_oidc_validator.audience` | result | server log |
|---|---|---|
| `postgres-client,"unterminated` | **REFUSED** | `list syntax is invalid` |
| `postgres-client,""` | **REFUSED** | `audience must not be empty` |
| `a,,b` | **REFUSED** | `list syntax is invalid` |

Both at reload and with the value already present when the postmaster starts — the case that used to
fail open:

```
WARNING:  invalid value for parameter "pg_oidc_validator.audience": "postgres-client,"unterminated"
DETAIL:  list syntax is invalid
HINT:  OAuth logins are refused until this is corrected.
WARNING:  OAuth failed: pg_oidc_validator.audience is invalid: list syntax is invalid
SHOW pg_oidc_validator.audience  ->  postgres-client,"unterminated
```

### JWKS `use`

| key | this PR | before 3db6549 |
|---|---|---|
| `use: "sig"` | **ACCEPTED** | ACCEPTED |
| *no `use` member* | **ACCEPTED** | 🔴 **REFUSED** — `Required parameter 'use' is missing` |
| `use: "enc"` | **REFUSED** (`wrong algorithm`) | REFUSED |

### `GUC_LIST_QUOTE`

Same environment, building the branch with the flag put back:

```
[patched]  LOAD  ->  postgres-client, "aud with space"
[reverted] FATAL:  extensions cannot define GUC_LIST_QUOTE variables
```

### Build

PGXS against PostgreSQL 18.6, g++ 14.2, no new warnings; `clang-format --dry-run --Werror` clean over
`src/`.
